### PR TITLE
Fix Google secret env var

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -7,7 +7,7 @@ export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
       clientId: process.env.WEB_CLIENT_ID!,
-      clientSecret: process.env.WEB_CLIENT_KEY!,
+      clientSecret: process.env.WEB_CLIENT_SECRET!,
     }),
   ],
   callbacks: {

--- a/app/lib/authOptions.ts
+++ b/app/lib/authOptions.ts
@@ -5,7 +5,7 @@ export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
       clientId: process.env.WEB_CLIENT_ID!,
-      clientSecret: process.env.WEB_CLIENT_KEY!,
+      clientSecret: process.env.WEB_CLIENT_SECRET!,
     }),
   ],
   callbacks: {


### PR DESCRIPTION
## Summary
- fix Google provider env var name in NextAuth setup

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684957e74ae883259568b2c89aec74f1