### PR TITLE
Fix duplicate authOptions in route

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,27 +1,9 @@
 import NextAuth from "next-auth";
-import GoogleProvider from "next-auth/providers/google";
-import { NextAuthOptions } from "next-auth";
 import { authOptions } from "@/app/lib/authOptions";
 
-export const authOptions: NextAuthOptions = {
-  providers: [
-    GoogleProvider({
-      clientId: process.env.WEB_CLIENT_ID!,
-      clientSecret: process.env.WEB_CLIENT_KEY!,
-    }),
-  ],
-  callbacks: {
-    async session({ session, token }) {
-      session.user.username = session.user.name
-        ?.split(" ")
-        .join("")
-        .toLowerCase();
-      session.user.uid = token.sub;
-      return session;
-    },
-  },
-  secret: process.env.NEXTAUTH_SECRET!,
-};
-
+// Reuse the shared authOptions from the lib folder to avoid
+// re-declaring the configuration in this route.
+// NextAuth will handle GET and POST requests using this config.
 const handler = NextAuth(authOptions);
+
 export { handler as GET, handler as POST };

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -1,7 +1,7 @@
 import Chat from "../../components/Chat";
 import ChatInput from "../../components/ChatInput";
 import { getServerSession } from "next-auth";
-import { authOptions } from "../../api/auth/[...nextauth]/route";
+import { authOptions } from "../../lib/authOptions";
 
 type Props = {
   params: { chatId: string };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import SessionProvider from './components/SessionProvider'
 import { getServerSession } from "next-auth";
 import Login from './components/Login'
 import ClientProvider from './components/ClientProvider'
-import { authOptions } from './api/auth/[...nextauth]/route';
+import { authOptions } from './lib/authOptions';
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -20,7 +20,7 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
-  const session = await getServerSession(authOption);
+  const session = await getServerSession(authOptions);
 
   return (
     <html lang="en">


### PR DESCRIPTION
## Summary
- import shared auth options in NextAuth route

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495c90f7448325864be2dd110e76ca