### PR TITLE
Fix NextAuth types for user fields

### DIFF
--- a/app/components/SessionProvider.tsx
+++ b/app/components/SessionProvider.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 function SessionProvider({ children, session }: Props) {
-  return <Provider>{children}</Provider>;
+  return <Provider session={session}>{children}</Provider>;
 }
 
 export default SessionProvider;

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,10 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session extends DefaultSession {
+    user: DefaultSession["user"] & {
+      username?: string;
+      uid?: string;
+    };
+  }
+}

--- a/typing.d.ts
+++ b/typing.d.ts
@@ -1,6 +1,6 @@
 interface Message {
     text: string;
-  
+
     createdAt: admin.firestore.Timestamp;
     user: {
       name: string;


### PR DESCRIPTION
## Summary
- add custom `next-auth` module declaration for `username` and `uid`
- clean `SessionProvider` component code
- remove stray text in `typing.d.ts`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684978261df883258930d17aa8d5dabe